### PR TITLE
Set correct format for polyfill for HTML5 datepicker

### DIFF
--- a/resources/assets/js/datePicker.js
+++ b/resources/assets/js/datePicker.js
@@ -1,23 +1,19 @@
 /**
- * Data picker input
- *
- *
- * This is a *private* plugin, and should only be used by Message Digital Design.
+ * Data picker polyfill for browsers that do not natively support the HTML5
+ * "date" input type.
  *
  * @author Message Digital Design <dev@message.co.uk>
  * @author Richard McCartney <richard@message.co.uk>
  */
-
 $(function() {
+	var testDateField = document.createElement('input');
 
-	// Add jQuery UI datepicker to date fields if browser does not support them
-	var testDateField, supportsDateField;
-	testDateField = document.createElement('input');
 	testDateField.setAttribute('type', 'date');
-	supportsDateField = 'date' == testDateField.type;
 
-	if (false == supportsDateField) {
-		$('input[type="date"]').datepicker();
+	// If the browser does not support the date input type, init the polyfill
+	if ('date' !== testDateField.type) {
+		$('input[type="date"]').datepicker({
+			dateFormat: "yy-mm-dd"
+		});
 	}
-
 });


### PR DESCRIPTION
#### What does this do?

Sets the date format for the jQuery UI polyfill for when the browser does not support HTML5 date inputs correctly. Previously, the default was US format (`MM/DD/YYYY`). This caused problems with the back-end because the form component did not expect dates in this format.

The standard seems to be to use `YYYY-MM-DD` which is actually what Chrome uses behind the scenes (even though it displays it as `DD/MM/YYYY`).

This should work with both the new pure-Symfony form component and the deprecated Cog form component.

I also tidied the code up a bit and improved the documentation a little.
#### How should this be manually tested?

Get it alised/namespace overridden then try to create a discount with a start and/or expiry date in Safari (which does not support HTML5 date inputs). Then try to create a voucher with a start date.

Discount uses new form component; vouchers use old form component.

Also test in a browser that **does** support HTML5 date inputs such as Chrome.
#### Related PRs / Issues / Resources?

Issue originally reported by Uniform Wares: https://trello.com/c/oBk6u7hG
#### Anything else to add? (Screenshots, background context, etc)

N/a
