### PR TITLE
Remove pound sign from bar graph dashboard module view

### DIFF
--- a/resources/view/module/dashboard/bar-graph.html.twig
+++ b/resources/view/module/dashboard/bar-graph.html.twig
@@ -18,7 +18,7 @@
 	},
 	"hAxis": {
 		"minValue": 0,
-		"format": "£#,###"
+		"format": "#,###"
 	},
 	"animation": {
 		"duration": 1000,


### PR DESCRIPTION
#### What does this do?

Removed the currency symbol from the X-axis on the bar graph view. This is currently only used by the "popular products" dataset at the moment where the value is a number not a currency value.

Note that it may be necessary to bring other dashboard graph views in line with this in future and make the controllers handling the requests to just add the currency symbols where appropriate or to provide its own format override, but that may well be BC breaking and is not required until the bar graph view is used by a different dashboard module so I'm leaving it for now.
#### How should this be manually tested?

Have a look at a Mothership installation that had dashboards and observe messagedigital/cog-mothership-commerce#362 in action. Add in a namespace override for `Mothership\ControlPanel` for this branch and refresh - you should see the issue is now resolved.
#### Related PRs / Issues / Resources?

Closes messagedigital/cog-mothership-commerce#362
#### Anything else to add? (Screenshots, background context, etc)
