### PR TITLE
Blog comment broken table fix

### DIFF
--- a/resources/assets/css/basic.css
+++ b/resources/assets/css/basic.css
@@ -955,6 +955,7 @@ table {
 	text-align: left;
 	font-size: 0.9em;
 	border-bottom: 1px solid #CCC;
+	table-layout: fixed;
 }
 
 table th {
@@ -977,6 +978,8 @@ table td {
 	text-align: left;
 	font-family:'Proxima N W15 Reg', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 	font-weight: normal;
+	word-wrap: break-word;
+
 }
 
 table tr {


### PR DESCRIPTION
#### What does this do?

Fixes the table layout for text that may exceed the table cell width. I.E. If you put in a fun comment like "sdjksfsdf"x100 without any breaks. 
#### How should this be manually tested?

Make a comment using the above fun method and check that it does not break the Comments table in the admin panel by stretching the table waaaaaay across the screen. 
#### Related PRs / Issues / Resources?

You can find all info here: https://trello.com/c/IyWOTvxW/1215-cms-blog-comments

Misc associated PRs:
CMS
https://github.com/messagedigital/cog-mothership-cms/pull/235
Cog
https://github.com/messagedigital/cog/pull/400
https://github.com/messagedigital/cog/pull/399
MS User
https://github.com/messagedigital/cog-mothership-user/pull/64
Union
https://github.com/messagedigital/union-music-store/pull/224
#### Anything else to add? (Screenshots, background context, etc)
