### PR TITLE
Adding fix for weird table bug in FF

### DIFF
--- a/resources/assets/css/basic.css
+++ b/resources/assets/css/basic.css
@@ -988,7 +988,7 @@ table {
 	text-align: left;
 	font-size: 0.9em;
 	border-bottom: 1px solid #CCC;
-	table-layout: fixed;
+	clear: both;
 }
 
 table th {


### PR DESCRIPTION
#### What does this do?

Fixes a weird bug in FF where tables appear way off to the right (i.e. in Fullfillment)
#### How should this be manually tested?

Look at it, and any other tables you can think of in both FF and Chrome and make sure everyone looks okay. 
#### Related PRs / Issues / Resources?

UAT Trello card: https://trello.com/c/f51VNkmI/25-fulfillment-display-of-new-orders-not-working
