### PR TITLE
overflow text in definition list terms with ellipsis.

### DIFF
--- a/resources/assets/css/cp.css
+++ b/resources/assets/css/cp.css
@@ -1729,6 +1729,9 @@
 	float: left;
 	font-family: 'Proxima N W15 Smbd', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 	min-height: 20px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .content dd {


### PR DESCRIPTION
I made this a feature branch by habit but it's not really a feature unless you get really excited about definition list terms having ellipses at the end...  
#### What does this do?

It makes the definition lists have ellipses at the end if the text is longer than the space available (i.e. in the case of the ZIP Code / Postal Code translation for Stoneham). 
#### How should this be manually tested?

You should be able to see it in the ZIP Code / Postal Code translation for Stoneham
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
