### PR TITLE
Extendable styles and JS

### DIFF
--- a/resources/view/_templates/assets/javascripts.html.twig
+++ b/resources/view/_templates/assets/javascripts.html.twig
@@ -1,0 +1,31 @@
+{% block include_js %}
+	{% javascripts
+		'@Message:Mothership:ControlPanel::resources/assets/js/components/history.js/scripts/bundled/html5/jquery.history.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/ModalHandler.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/cp-setup.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/livePane.jquery.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/nestedAccordian.jquery.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/selectAllToggle.jquery.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/forms.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/help.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/title.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/dropdown.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/feedback.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/datePicker.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/components/masonry/masonry.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/components/googleChart/jsapi.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/components/googleChart/attc.googleChart.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/select2.min.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/jquery.dataTables.min.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/dataTables.column-filter.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/components/medium-editor/medium-editor.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/components/medium-editor/me-markdown.standalone.js'
+		'@Message:Mothership:ControlPanel::resources/assets/js/wysiwyg.js'
+
+		output='/assets/js/ms_cp.js'
+		filter='?jsmin'
+
+	%}
+	<script src="{{ asset_url }}"></script>
+	{% endjavascripts %}
+{% endblock %}

--- a/resources/view/_templates/assets/stylesheets.html.twig
+++ b/resources/view/_templates/assets/stylesheets.html.twig
@@ -1,0 +1,11 @@
+{% block include_css %}
+	{% stylesheets
+		'@Message:Mothership:ControlPanel::resources/assets/css/components/medium-editor/medium-editor.css'
+		'@Message:Mothership:ControlPanel::resources/assets/css/cp.css'
+
+		output='/assets/css/ms_cp.css'
+		filter='csscogulerewrite,?cssmin'
+	%}
+	<link rel="stylesheet" href="{{ asset_url }}">
+	{% endstylesheets %}
+{% endblock %}

--- a/resources/view/_templates/cp.html.twig
+++ b/resources/view/_templates/cp.html.twig
@@ -1,49 +1,13 @@
-{% extends '::_templates/main' %}
+{% extends 'Message:Mothership:ControlPanel::_templates/main' %}
 
 {% block stylesheets %}
 	{{ parent() }}
-	{% stylesheets
-		'@Message:Mothership:ControlPanel::resources/assets/css/components/medium-editor/medium-editor.css'
-		'@Message:Mothership:ControlPanel::resources/assets/css/cp.css'
-
-		output='/assets/css/ms_cp.css'
-		filter='csscogulerewrite,?cssmin'
-	%}
-		<link rel="stylesheet" href="{{ asset_url }}">
-	{% endstylesheets %}
+	{% include 'Message:Mothership:ControlPanel::extensions:stylesheets' %}
 {% endblock %}
 
 {% block javascripts %}
 	{{ parent() }}
-	{% javascripts
-		'@Message:Mothership:ControlPanel::resources/assets/js/components/history.js/scripts/bundled/html5/jquery.history.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/ModalHandler.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/cp-setup.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/livePane.jquery.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/nestedAccordian.jquery.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/selectAllToggle.jquery.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/forms.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/help.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/title.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/dropdown.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/feedback.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/datePicker.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/components/masonry/masonry.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/components/googleChart/jsapi.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/components/googleChart/attc.googleChart.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/select2.min.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/jquery.dataTables.min.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/dataTables.column-filter.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/components/medium-editor/medium-editor.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/components/medium-editor/me-markdown.standalone.js'
-		'@Message:Mothership:ControlPanel::resources/assets/js/wysiwyg.js'
-
-		output='/assets/js/ms_cp.js'
-		filter='?jsmin'
-
-	%}
-		<script src="{{ asset_url }}"></script>
-	{% endjavascripts %}
+	{% include 'Message:Mothership:ControlPanel::extensions:javascripts' %}
 {% endblock %}
 {% block body %}
 	<div class="container-cp">

--- a/resources/view/extensions/javascripts.html.twig
+++ b/resources/view/extensions/javascripts.html.twig
@@ -1,0 +1,12 @@
+{# Override this view to add javascript files for admin panel customisation #}
+{% extends 'Message:Mothership:ControlPanel::_templates:assets:javascripts' %}
+
+{% block include_js %}
+	{{ parent() }}
+	{% javascripts
+		output='/assets/js/ms_ext_cp.js'
+		filter='?jsmin'
+	%}
+	<script src="{{ asset_url }}"></script>
+	{% endjavascripts %}
+{% endblock %}

--- a/resources/view/extensions/stylesheets.html.twig
+++ b/resources/view/extensions/stylesheets.html.twig
@@ -1,0 +1,12 @@
+{# Override this view to add CSS files for admin panel customisation #}
+{% extends 'Message:Mothership:ControlPanel::_templates:assets:stylesheets' %}
+
+{% block include_css %}
+	{{ parent() }}
+	{% stylesheets
+		output='/assets/css/ms_ext_cp.css'
+		filter='csscogulerewrite,?cssmin'
+	%}
+	<link rel="stylesheet" href="{{ asset_url }}">
+	{% endstylesheets %}
+{% endblock %}


### PR DESCRIPTION
This PR adds two new files intended to be overridden for custom styles and JavaScript in the admin panel. These can be extended by overriding `Message:Mothership:ControlPanel::extensions:stylesheets` and `Message:Mothership:ControlPanel::extensions:javascripts`