### PR TITLE
Barcode spacing tweaks

### DIFF
--- a/resources/assets/css/cp.css
+++ b/resources/assets/css/cp.css
@@ -3574,18 +3574,26 @@ table tr.grandtotal:nth-child(even) td, table tr.grandtotal:nth-child(odd) td  {
 .currency-units .field {
 	width: auto;
 	float: left;
-	max-width: 220px;
+	max-width: 320px;
 }
 
+.currency-units .field input {
+	width: 100%;
+}
 
 .currency-group .module .add-on,
 .currency-units .add-on {
 	margin-bottom: 0;
+	width: 100%;
+	max-width: 100%;
 }
 
 .currency-group .module .add-on div,
 .currency-units .add-on div  {
 	width: 65%;
+	width: -webkit-calc(100% - 27px);
+	width: -moz-calc(100% - 27px);
+	width: calc(100% - 27px);
 }
 
 .currency-group .module .help,

--- a/resources/assets/css/cp.css
+++ b/resources/assets/css/cp.css
@@ -3575,6 +3575,7 @@ table tr.grandtotal:nth-child(even) td, table tr.grandtotal:nth-child(odd) td  {
 	width: auto;
 	float: left;
 	max-width: 250px;
+	padding-right: 10px;
 }
 
 .currency-units .field input {

--- a/resources/assets/css/cp.css
+++ b/resources/assets/css/cp.css
@@ -3574,7 +3574,7 @@ table tr.grandtotal:nth-child(even) td, table tr.grandtotal:nth-child(odd) td  {
 .currency-units .field {
 	width: auto;
 	float: left;
-	max-width: 320px;
+	max-width: 250px;
 }
 
 .currency-units .field input {
@@ -3591,9 +3591,9 @@ table tr.grandtotal:nth-child(even) td, table tr.grandtotal:nth-child(odd) td  {
 .currency-group .module .add-on div,
 .currency-units .add-on div  {
 	width: 65%;
-	width: -webkit-calc(100% - 27px);
-	width: -moz-calc(100% - 27px);
-	width: calc(100% - 27px);
+	width: -webkit-calc(100% - 28px);
+	width: -moz-calc(100% - 28px);
+	width: calc(100% - 28px);
 }
 
 .currency-group .module .help,
@@ -3603,6 +3603,10 @@ table tr.grandtotal:nth-child(even) td, table tr.grandtotal:nth-child(odd) td  {
 
 .currency-units {
 	display: inline-block;
+}
+
+.group .currency-units .field {
+	padding-right: 10px;
 }
 
 /* Pagination


### PR DESCRIPTION
#### What does this do?

Makes price fields wider and more flexible since the new barcodes button was causing table cells to become smaller, therefore making the 70% width fields quite narrow. 

#### How should this be manually tested?

#### Related PRs / Issues / Resources?

#### Anything else to add? (Screenshots, background context, etc)