### PR TITLE
Only make group titles draggable

### DIFF
--- a/resources/assets/js/forms.js
+++ b/resources/assets/js/forms.js
@@ -7,6 +7,8 @@
 
 	var setupSort = function() {
 		$('.repeatable-group .sortable').sortable({
+			connectWith: '.repeatable-group .sortable',
+			handle: '.title',
 			stop: function() {
 				var seq = 0;
 


### PR DESCRIPTION
Fixes issue with re-ordering repeatable groups where it would disable the WYSIWYG editor when trying to select text